### PR TITLE
allow plugin to be used with React 15+

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "author": "Abraham Polishchuk <apolishc@gmail.com>",
   "peerDependencies": {
-    "react": "^15.0.0-0 || ^16.0.0-0",
+    "react": ">=15",
     "gatsby": ">=1"
   },
   "devDependencies": {


### PR DESCRIPTION
NPM 7 complains about this, and I don't see a reason why this plugin can't work with React 17. This PR updates the semver to support later versions of React.